### PR TITLE
+ a shorthand for m.component

### DIFF
--- a/src/main/scala/co/technius/scalajs/mithril/Mithril.scala
+++ b/src/main/scala/co/technius/scalajs/mithril/Mithril.scala
@@ -30,6 +30,7 @@ trait MithrilCore extends js.Object {
   def withAttr(attr: String, callback: js.Function): js.Function = js.native
   def withAttr(attr: String, callback: MithrilProp[_]): js.Function = js.native
 
+  def apply(component: MithrilComponent, args: js.Any*): VirtualDom = js.native
   def component(component: MithrilComponent, args: js.Any*): VirtualDom = js.native
 }
 


### PR DESCRIPTION
> m(component, ...args) can now be used as a shorthand for m.component(component, ...args)
> since 0.2.1
